### PR TITLE
executor: add the interface of `DoDiff`

### DIFF
--- a/executor/server.go
+++ b/executor/server.go
@@ -1,0 +1,88 @@
+package executor
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/ngaut/log"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+// DoDiff executes sqls in the driver configured in exec. If there is an inconsistent sql execution result,
+// it will directly return an error, and the error message contains inconsistencies.
+// If the execution results are the same, no error is returned.
+// handleResultsFn is used to do special processing on the results after executing each statement.
+func DoDiff(exec *Executor, sqls []string, handleResultsFn func(strs []string)) error{
+	if len(sqls) == 0{
+		return nil
+	}
+
+	for _, sql := range sqls{
+		if err := diffExecResult(sql, exec, handleResultsFn);err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func diffExecResult(query string, exec *Executor, handleResultsFn func(str []string)()) error{
+ 	mysqlResult, tidbResult, err := exec.Query(query)
+ 	if err != nil {
+ 		return err
+ 	}
+ 	defer mysqlResult.Close()
+ 	defer tidbResult.Close()
+ 	mysqlContent, tidbContent := mysqlResult.Content(), tidbResult.Content()
+ 	if mysqlResult.Error == nil && tidbResult.Error == nil {
+		green := color.New(color.FgGreen).SprintFunc()
+		red := color.New(color.FgRed).SprintFunc()
+		patch := diffmatchpatch.New()
+		diff := patch.DiffMain(mysqlContent, tidbContent, false)
+		var newMySQLContent, newTiDBContent bytes.Buffer
+		for _, d := range diff {
+			switch d.Type {
+			case diffmatchpatch.DiffEqual:
+				newMySQLContent.WriteString(d.Text)
+				newTiDBContent.WriteString(d.Text)
+			case diffmatchpatch.DiffDelete:
+				newMySQLContent.WriteString(red(d.Text))
+			case diffmatchpatch.DiffInsert:
+				newTiDBContent.WriteString(green(d.Text))
+			}
+		}
+		mysqlContent = newMySQLContent.String()
+		tidbContent = newTiDBContent.String()
+	}
+
+ 	logQuery := query
+ 	if strings.HasPrefix(query, "!!") {
+ 		logQuery = mysqlResult.Rendered
+ 	}
+
+ 	if handleResultsFn != nil {
+ 		handleResultsFn([]string{mysqlContent, tidbContent})
+	}
+	if mysqlContent == tidbContent{
+		log.Info(query,"\nmysql:",mysqlContent, "\ntidb:", tidbContent)
+		return err
+	}
+
+	var buf bytes.Buffer
+ 	buf.WriteString(fmt.Sprintf("MySQL(%s)> %s\n", exec.MySQLConfig.Address(), logQuery))
+ 	if mysqlContent != "" {
+ 		buf.WriteString(mysqlContent)
+ 	}
+	buf.WriteString(mysqlResult.Stat()+"\n")
+ 	buf.WriteString(fmt.Sprintf("TiDB(%s)> %s\n", exec.TiDBConfig.Address(), logQuery))
+ 	if tidbContent != "" {
+ 		buf.WriteString(tidbContent)
+ 	}
+	buf.WriteString(tidbResult.Stat()+"\n")
+ 	return errors.New(buf.String())
+ }
+
+

--- a/executor/server.go
+++ b/executor/server.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/ngaut/log"
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
@@ -15,13 +14,13 @@ import (
 // it will directly return an error, and the error message contains inconsistencies.
 // If the execution results are the same, no error is returned.
 // handleResultsFn is used to do special processing on the results after executing each statement.
-func DoDiff(exec *Executor, sqls []string, handleResultsFn func(strs []string)) error{
-	if len(sqls) == 0{
+func (exec *Executor) DoDiff(sqls []string, handleResultsFn func(strs []string)) error {
+	if len(sqls) == 0 {
 		return nil
 	}
 
-	for _, sql := range sqls{
-		if err := diffExecResult(sql, exec, handleResultsFn);err != nil {
+	for _, sql := range sqls {
+		if err := exec.diffExecResult(sql, handleResultsFn); err != nil {
 			return err
 		}
 	}
@@ -29,15 +28,15 @@ func DoDiff(exec *Executor, sqls []string, handleResultsFn func(strs []string)) 
 	return nil
 }
 
-func diffExecResult(query string, exec *Executor, handleResultsFn func(str []string)()) error{
- 	mysqlResult, tidbResult, err := exec.Query(query)
- 	if err != nil {
- 		return err
- 	}
- 	defer mysqlResult.Close()
- 	defer tidbResult.Close()
- 	mysqlContent, tidbContent := mysqlResult.Content(), tidbResult.Content()
- 	if mysqlResult.Error == nil && tidbResult.Error == nil {
+func (exec *Executor) diffExecResult(query string, handleResultsFn func(str []string)) error {
+	mysqlResult, tidbResult, err := exec.Query(query)
+	if err != nil {
+		return err
+	}
+	defer mysqlResult.Close()
+	defer tidbResult.Close()
+	mysqlContent, tidbContent := mysqlResult.Content(), tidbResult.Content()
+	if mysqlResult.Error == nil && tidbResult.Error == nil {
 		green := color.New(color.FgGreen).SprintFunc()
 		red := color.New(color.FgRed).SprintFunc()
 		patch := diffmatchpatch.New()
@@ -58,31 +57,28 @@ func diffExecResult(query string, exec *Executor, handleResultsFn func(str []str
 		tidbContent = newTiDBContent.String()
 	}
 
- 	logQuery := query
- 	if strings.HasPrefix(query, "!!") {
- 		logQuery = mysqlResult.Rendered
- 	}
-
- 	if handleResultsFn != nil {
- 		handleResultsFn([]string{mysqlContent, tidbContent})
+	logQuery := query
+	if strings.HasPrefix(query, "!!") {
+		logQuery = mysqlResult.Rendered
 	}
-	if mysqlContent == tidbContent{
-		log.Info(query,"\nmysql:",mysqlContent, "\ntidb:", tidbContent)
-		return err
+
+	if handleResultsFn != nil {
+		handleResultsFn([]string{mysqlContent, tidbContent})
+	}
+	if mysqlContent == tidbContent {
+		return nil
 	}
 
 	var buf bytes.Buffer
- 	buf.WriteString(fmt.Sprintf("MySQL(%s)> %s\n", exec.MySQLConfig.Address(), logQuery))
- 	if mysqlContent != "" {
- 		buf.WriteString(mysqlContent)
- 	}
-	buf.WriteString(mysqlResult.Stat()+"\n")
- 	buf.WriteString(fmt.Sprintf("TiDB(%s)> %s\n", exec.TiDBConfig.Address(), logQuery))
- 	if tidbContent != "" {
- 		buf.WriteString(tidbContent)
- 	}
-	buf.WriteString(tidbResult.Stat()+"\n")
- 	return errors.New(buf.String())
- }
-
-
+	buf.WriteString(fmt.Sprintf("MySQL(%s)> %s\n", exec.MySQLConfig.Address(), logQuery))
+	if mysqlContent != "" {
+		buf.WriteString(mysqlContent)
+	}
+	buf.WriteString(mysqlResult.Stat() + "\n")
+	buf.WriteString(fmt.Sprintf("TiDB(%s)> %s\n", exec.TiDBConfig.Address(), logQuery))
+	if tidbContent != "" {
+		buf.WriteString(tidbContent)
+	}
+	buf.WriteString(tidbResult.Stat() + "\n")
+	return errors.New(buf.String())
+}

--- a/executor/server_test.go
+++ b/executor/server_test.go
@@ -1,0 +1,36 @@
+package executor
+
+import (
+	"fmt"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var defaultMySQLDSNConfig = &Config{
+	User:   "root",
+	Host:  "localhost",
+	Port:   3306,
+	DB: "test",
+	Options: "charset=utf8mb4&collation=utf8mb4_bin",
+}
+
+var defaultTiDBDSNConfig = &Config{
+	User:   "root",
+	Host:  "127.0.0.1",
+	Port:   4000,
+	DB: "test",
+	Options: "charset=utf8mb4&collation=utf8mb4_bin",
+}
+
+func Example(){
+	exec := NewExecutor(defaultMySQLDSNConfig, defaultTiDBDSNConfig)
+	if err := exec.Open(DefaultRetryCnt); err != nil {
+		fmt.Printf("open failed err %v", err)
+		return
+	}
+
+	sqls:=[]string{"drop table t", "create table t(a int)","show create table t", "drop table t"}
+	if err := DoDiff(exec, sqls, nil); err != nil{
+		fmt.Printf("do diff failed \n%v", err)
+	}
+}

--- a/executor/server_test.go
+++ b/executor/server_test.go
@@ -7,30 +7,30 @@ import (
 )
 
 var defaultMySQLDSNConfig = &Config{
-	User:   "root",
-	Host:  "localhost",
-	Port:   3306,
-	DB: "test",
+	User:    "root",
+	Host:    "localhost",
+	Port:    3306,
+	DB:      "test",
 	Options: "charset=utf8mb4&collation=utf8mb4_bin",
 }
 
 var defaultTiDBDSNConfig = &Config{
-	User:   "root",
-	Host:  "127.0.0.1",
-	Port:   4000,
-	DB: "test",
+	User:    "root",
+	Host:    "127.0.0.1",
+	Port:    4000,
+	DB:      "test",
 	Options: "charset=utf8mb4&collation=utf8mb4_bin",
 }
 
-func Example(){
+func Example() {
 	exec := NewExecutor(defaultMySQLDSNConfig, defaultTiDBDSNConfig)
 	if err := exec.Open(DefaultRetryCnt); err != nil {
 		fmt.Printf("open failed err %v", err)
 		return
 	}
 
-	sqls:=[]string{"drop table t", "create table t(a int)","show create table t", "drop table t"}
-	if err := DoDiff(exec, sqls, nil); err != nil{
+	sqls := []string{"drop table t", "create table t(a int)", "show create table t", "drop table t"}
+	if err := exec.DoDiff(sqls, nil); err != nil {
 		fmt.Printf("do diff failed \n%v", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -199,7 +199,7 @@ func serve(ctx *cli.Context) error {
 		return err
 	}
 	exec := executor.NewExecutor(dbConfig("mysql", ctx), dbConfig("tidb", ctx))
-	if err := exec.Open(); err != nil {
+	if err := exec.Open(executor.DefaultRetryCnt); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Add the interface of `DoDiff` to execute sqls in the driver configured in exec. If there is an inconsistent sql execution result, it will directly return an error, and the error message contains inconsistencies. If the execution results are the same, no error is returned.
And use `openDBWithRetry` instead of `sql.Open` in `executor.Open`.